### PR TITLE
Add a reference to context settings and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module.exports = ruleComposer.joinReports([
 ]);
 ```
 
-You can access options set on a rule. The following example creates a modified version of the [`no-unused-expressions`](https://eslint.org/docs/rules/no-unused-expressions) rule which accepts a list of exceptions.
+You can access rule's options and [shared settings](https://eslint.org/docs/user-guide/configuring#adding-shared-settings) from the current ESLint configuration. The following example creates a modified version of the [`no-unused-expressions`](https://eslint.org/docs/rules/no-unused-expressions) rule which accepts a list of exceptions.
 
 ```js
 
@@ -71,40 +71,6 @@ module.exports = ruleComposer.filterReports(
   }
 );
 ```
-
-You can also access [shared settings](https://eslint.org/docs/user-guide/configuring#adding-shared-settings) from the current ESLint configuration file:
-
-
-```js
-
-/*
-  .eslint.json:
-
-  {
-    "settings": {
-      "tokenWhitelist": ["expect", "test"]
-    },
-    "rules": {
-      "custom-no-unused-expressions": "error"
-    }
-  }
-  
-*/
-
-const ruleComposer = require('eslint-rule-composer');
-const eslint = require('eslint');
-const noUnusedExpressionsRule = new eslint.Linter().getRules().get('no-unused-expressions');
-
-module.exports = ruleComposer.filterReports(
-  noUnusedExpressionsRule,
-  (problem, metadata) => {
-    const firstToken = metadata.sourceCode.getFirstToken(problem.node);
-    const whitelist = settings.tokenWhitelist;
-    return !whitelist.includes(value);
-  }
-);
-```
-
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module.exports = ruleComposer.filterReports(
   (problem, metadata) => {
     const firstToken = metadata.sourceCode.getFirstToken(problem.node);
     const whitelist = settings.tokenWhitelist;
-    return whitelist.includes(value) === false
+    return !whitelist.includes(value);
   }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,68 @@ module.exports = ruleComposer.joinReports([
 ]);
 ```
 
+You can access options set on a rule. The following example creates a modified version of the [`no-unused-expressions`](https://eslint.org/docs/rules/no-unused-expressions) rule which accepts a list of exceptions.
+
+```js
+
+/*
+  rule configuration:
+
+  {
+    "custom-no-unused-expressions": ["error", {
+      "whitelist": ["expect", "test"]
+    }]
+  }
+*/
+
+const ruleComposer = require('eslint-rule-composer');
+const eslint = require('eslint');
+const noUnusedExpressionsRule = new eslint.Linter().getRules().get('no-unused-expressions');
+
+module.exports = ruleComposer.filterReports(
+  noUnusedExpressionsRule,
+  (problem, metadata) => {
+    const firstToken = metadata.sourceCode.getFirstToken(problem.node);
+    const whitelist = metadata.options[0].whitelist;
+    return whitelist.includes(value) === false
+  }
+);
+```
+
+You can also access [shared settings](https://eslint.org/docs/user-guide/configuring#adding-shared-settings) from the current ESLint configuration file:
+
+
+```js
+
+/*
+  .eslint.json:
+
+  {
+    "settings": {
+      "tokenWhitelist": ["expect", "test"]
+    },
+    "rules": {
+      "custom-no-unused-expressions": "error"
+    }
+  }
+  
+*/
+
+const ruleComposer = require('eslint-rule-composer');
+const eslint = require('eslint');
+const noUnusedExpressionsRule = new eslint.Linter().getRules().get('no-unused-expressions');
+
+module.exports = ruleComposer.filterReports(
+  noUnusedExpressionsRule,
+  (problem, metadata) => {
+    const firstToken = metadata.sourceCode.getFirstToken(problem.node);
+    const whitelist = settings.tokenWhitelist;
+    return whitelist.includes(value) === false
+  }
+);
+```
+
+
 ## API
 
 ### `ruleComposer.filterReports(rule, predicate)` and `ruleComposer.mapReports(rule, predicate)`
@@ -74,7 +136,11 @@ In both cases, `predicate` is called with two arguments: `problem` and `metadata
     Note that the `messageId` and `data` properties will only be present if the original rule reported a problem using [Message IDs](https://eslint.org/docs/developer-guide/working-with-rules#messageids), otherwise they will be null.
 
     When returning a descriptor with `mapReports`, the `messageId` property on the returned descriptor will be used to generate the new message. To modify a report message directly for a rule that uses message IDs, ensure that the `predicate` function returns an object without a `messageId` property.
-* `metadata` is an object containing information about the source text that was linted. This has a `sourceCode` property, which is a [`SourceCode`](https://eslint.org/docs/developer-guide/working-with-rules#contextgetsourcecode) instance corresponding to the linted text.
+* `metadata` is an object containing information about the source text that was linted. This has the following properties:
+
+* `sourceCode`: a [`SourceCode`](https://eslint.org/docs/developer-guide/working-with-rules#contextgetsourcecode) instance corresponding to the linted text.
+* `settings`: linter instance's [shared settings](https://eslint.org/docs/user-guide/configuring#adding-shared-settings)
+* `options`: rule's [configuration options](https://eslint.org/docs/developer-guide/working-with-rules#contextoptions)
 
 ### `ruleComposer.joinReports(rules)`
 

--- a/lib/rule-composer.js
+++ b/lib/rule-composer.js
@@ -129,6 +129,8 @@ module.exports = Object.freeze({
     return Object.freeze({
       create(context) {
         const sourceCode = context.getSourceCode();
+        const settings = context.settings;
+        const options = context.options;
         return getRuleCreateFunc(rule)(
           Object.freeze(
             Object.create(
@@ -138,7 +140,7 @@ module.exports = Object.freeze({
                   enumerable: true,
                   value() {
                     const reportDescriptor = getReportNormalizer(rule).apply(null, arguments);
-                    if (predicate(reportDescriptor, { sourceCode })) {
+                    if (predicate(reportDescriptor, { sourceCode, settings, options })) {
                       context.report(removeMessageIfMessageIdPresent(reportDescriptor));
                     }
                   },
@@ -156,6 +158,8 @@ module.exports = Object.freeze({
     return Object.freeze({
       create(context) {
         const sourceCode = context.getSourceCode();
+        const settings = context.settings;
+        const options = context.options;
         return getRuleCreateFunc(rule)(
           Object.freeze(
             Object.create(
@@ -168,7 +172,7 @@ module.exports = Object.freeze({
                       removeMessageIfMessageIdPresent(
                         iteratee(
                           getReportNormalizer(rule).apply(null, arguments),
-                          { sourceCode }
+                          { sourceCode, settings, options }
                         )
                       )
                     );

--- a/tests/lib/rule-composer.js
+++ b/tests/lib/rule-composer.js
@@ -38,7 +38,7 @@ ruleTester.run(
 ruleTester.run(
   'filterReports - with settings',
   ruleComposer.filterReports(coreRules.get('no-undef'), (descriptor, m) => (
-    descriptor.node && m.settings.tokenWhitelist.includes(descriptor.node.name) === false
+    descriptor.node && m.settings.tokenWhitelist.indexOf(descriptor.node.name) === -1
   )),
   {
     valid: [
@@ -72,7 +72,7 @@ ruleTester.run(
 );
 
 const ruleWithOptions = ruleComposer.filterReports(coreRules.get('no-undef'), (descriptor, m) => (
-  descriptor.node && m.options[0].tokenWhitelist.includes(descriptor.node.name) === false
+  descriptor.node && m.options[0].tokenWhitelist.indexOf(descriptor.node.name) === -1
 ));
 
 // overwrite schema to allow custom options...

--- a/tests/lib/rule-composer.js
+++ b/tests/lib/rule-composer.js
@@ -33,6 +33,85 @@ ruleTester.run(
   }
 );
 
+// test with settings
+
+ruleTester.run(
+  'filterReports - with settings',
+  ruleComposer.filterReports(coreRules.get('no-undef'), (descriptor, m) => (
+    descriptor.node && m.settings.tokenWhitelist.includes(descriptor.node.name) === false
+  )),
+  {
+    valid: [
+      {
+        code: 'foo;',
+        settings: { tokenWhitelist: ['foo'] },
+      },
+      {
+        code: 'var bar; bar;',
+        settings: { tokenWhitelist: ['foo'] },
+      },
+    ],
+    invalid: [
+      {
+        code: 'bar;',
+        errors: [{ line: 1, column: 1 }],
+        settings: { tokenWhitelist: ['foo'] },
+      },
+      {
+        code: 'foo; bar;',
+        errors: [{ line: 1, column: 6 }],
+        settings: { tokenWhitelist: ['foo'] },
+      },
+      {
+        code: 'bar; foo;',
+        errors: [{ line: 1, column: 1 }],
+        settings: { tokenWhitelist: ['foo'] },
+      },
+    ],
+  }
+);
+
+const ruleWithOptions = ruleComposer.filterReports(coreRules.get('no-undef'), (descriptor, m) => (
+  descriptor.node && m.options[0].tokenWhitelist.includes(descriptor.node.name) === false
+));
+
+// overwrite schema to allow custom options...
+ruleWithOptions.meta.schema[0].additionalProperties = true;
+
+ruleTester.run(
+  'filterReports - with options',
+  ruleWithOptions,
+  {
+    valid: [
+      {
+        code: 'foo;',
+        options: [{ tokenWhitelist: ['foo'] }],
+      },
+      {
+        code: 'var bar; bar;',
+        options: [{ tokenWhitelist: ['foo'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: 'bar;',
+        errors: [{ line: 1, column: 1 }],
+        options: [{ tokenWhitelist: ['foo'] }],
+      },
+      {
+        code: 'foo; bar;',
+        errors: [{ line: 1, column: 6 }],
+        options: [{ tokenWhitelist: ['foo'] }],
+      },
+      {
+        code: 'bar; foo;',
+        errors: [{ line: 1, column: 1 }],
+        options: [{ tokenWhitelist: ['foo'] }],
+      },
+    ],
+  }
+);
+
 ruleTester.run(
   'joinReports',
   ruleComposer.joinReports([
@@ -69,6 +148,50 @@ ruleTester.run(
         errors: [
           { type: 'Program', message: 'FOO' },
         ],
+      },
+    ],
+  }
+);
+
+// test with settings
+
+ruleTester.run(
+  'mapReports - with settings',
+  ruleComposer.mapReports(
+    context => ({ Program: node => context.report({ node, message: 'foo' }) }),
+    (descriptor, m) => Object.assign({}, descriptor, { message: descriptor.message[m.settings.method]() })
+  ),
+  {
+    valid: [],
+    invalid: [
+      {
+        code: 'a',
+        errors: [
+          { type: 'Program', message: 'FOO' },
+        ],
+        settings: { method: 'toUpperCase' },
+      },
+    ],
+  }
+);
+
+// test with settings
+
+ruleTester.run(
+  'mapReports - with options',
+  ruleComposer.mapReports(
+    context => ({ Program: node => context.report({ node, message: 'foo' }) }),
+    (descriptor, m) => Object.assign({}, descriptor, { message: descriptor.message[m.options[0].method]() })
+  ),
+  {
+    valid: [],
+    invalid: [
+      {
+        code: 'a',
+        errors: [
+          { type: 'Program', message: 'FOO' },
+        ],
+        options: [{ method: 'toUpperCase' }],
       },
     ],
   }


### PR DESCRIPTION
Hi great project!

I'm using this library's `filterReports` to modify a rule i [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue/issues/389#issuecomment-367990429) but I'd like to be able to access rules' `options` and global `settings`.

For what I can understand reading the sourcecode, right now there's no way to access those property, so I extracted them from the context object and exposed them on the `metadata` object.