### PR TITLE
feat: add groupReports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ In both cases, `predicate` is called with two arguments: `problem` and `metadata
 
 Given an array of ESLint rule objects, `joinReports` returns a new rule that will report all of the problems from any of the rules in the array. The options provided to the new rule will also be provided to all of the rules in the array.
 
+### `ruleComposer.groupReports(rulesMap)`
+
+Given an object, keyed by rule ids, of ESLint rule objects; or arrays of which the first element is an ESLint rule object, and the second is that rule's option configuration; `groupReports` returns a new rule that will report all of the problems from any of the rules in the group. Any options provided to the new rule must be as an object, keyed by the respective rule ids, the values of which, if provided, will be used to override the options provided in the creation of the rule.
+
+This can be used to group rules together into a new group rule, but still allow for configuration of the sub-rules, either at the group rule's creation time, or at its configuration time.
+
 ### Getting a reference to an ESLint rule
 
 To get a reference to an ESLint core rule, you can use ESLint's [public API](https://eslint.org/docs/developer-guide/nodejs-api) like this:

--- a/lib/rule-composer.js
+++ b/lib/rule-composer.js
@@ -228,4 +228,68 @@ module.exports = Object.freeze({
       }),
     });
   },
+  groupReports(rulesMap) {
+    return Object.freeze({
+      create(context) {
+        const userOptions = arguments[0].options[0] || {};
+        return Object.keys(rulesMap)
+          .map((ruleId) => {
+            const ruleConfig = Array.prototype.concat(rulesMap[ruleId]);
+            const rule = ruleConfig[0];
+            const defaultOptions = ruleConfig[1];
+            const ruleContext = Object.create(context, {
+              options: {
+                value: Array.prototype.concat(userOptions[ruleId] || defaultOptions || []),
+              },
+              report: {
+                value(descriptor) {
+                  if (typeof descriptor === 'object' && descriptor.messageId) {
+                    context.report(Object.assign({}, descriptor, { messageId: `${ruleId}/${descriptor.messageId}` }));
+                  } else {
+                    context.report.apply(context, arguments);
+                  }
+                },
+              },
+            });
+            return getRuleCreateFunc(rule)(ruleContext);
+          })
+          .reduce(
+            (allListeners, ruleListeners) => Object.keys(ruleListeners).reduce(
+              (combinedListeners, key) => {
+                const currentListener = combinedListeners[key];
+                const ruleListener = ruleListeners[key];
+                if (currentListener) {
+                  return Object.assign({}, combinedListeners, {
+                    [key]() {
+                      currentListener.apply(null, arguments);
+                      ruleListener.apply(null, arguments);
+                    },
+                  });
+                }
+                return Object.assign({}, combinedListeners, { [key]: ruleListener });
+              },
+              allListeners
+            ),
+            Object.create(null)
+          );
+      },
+      meta: Object.freeze({
+        messages: Object.assign.apply(
+          null,
+          [Object.create(null)].concat(
+            Object.keys(rulesMap)
+              .map((ruleId) => {
+                const messageIds = getMessageIds(Array.prototype.concat(rulesMap[ruleId])[0]);
+                return Object.keys(messageIds)
+                  .reduce((acc, messageId) => {
+                    acc[`${ruleId}/${messageId}`] = messageIds[messageId];
+                    return acc;
+                  }, Object.create(null));
+              })
+          )
+        ),
+        fixable: 'code',
+      }),
+    });
+  },
 });

--- a/tests/lib/rule-composer.js
+++ b/tests/lib/rule-composer.js
@@ -162,6 +162,34 @@ ruleTester.run(
 );
 
 ruleTester.run(
+  'groupReports',
+  ruleComposer.groupReports({
+    foo: context => ({ Program: node => context.report(node, 'foo') }),
+    bar: context => ({ Program: node => context.report(node, context.options[0]) }),
+    baz: [context => ({ 'Program:exit': node => context.report(node, context.options[0]) }), 'bazDefault'],
+    qux: [{ create: context => ({ 'Program:exit': node => context.report(node, context.options[0]) }) }, 'quxDefault'],
+  }),
+  {
+    valid: [],
+    invalid: [
+      {
+        options: [{
+          bar: 'bar',
+          qux: 'qux',
+        }],
+        code: 'a',
+        errors: [
+          { type: 'Program', message: 'foo' },
+          { type: 'Program', message: 'bar' },
+          { type: 'Program', message: 'bazDefault' },
+          { type: 'Program', message: 'qux' },
+        ],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
   'mapReports',
   ruleComposer.mapReports(
     context => ({ Program: node => context.report({ node, message: 'foo' }) }),

--- a/tests/types/tests.ts
+++ b/tests/types/tests.ts
@@ -25,3 +25,9 @@ ruleComposer.mapReports(ruleModule, (problem, metadata) => {
 ruleComposer.filterReports(ruleModule, (problem, metadata) => false);
 
 ruleComposer.joinReports([ruleModule, ruleModule]);
+
+ruleComposer.groupReports({
+	foo: ruleModule,
+	bar: [ruleModule, ['barDefaultOption']],
+	baz: [ruleModule, [{ option: 'bazDefaultOption' }]],
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -34,3 +34,9 @@ export function filterReports(
 export function joinReports(
   rules: eslint.Rule.RuleModule[]
 ): eslint.Rule.RuleModule;
+
+export function groupReports(
+  rulesMap: {
+    [id: string]: eslint.Rule.RuleModule | [eslint.Rule.RuleModule, any[]],
+  }
+): eslint.Rule.RuleModule;


### PR DESCRIPTION
This is a follow-up from a [discussion in the ESLint gitter chat.](https://gitter.im/eslint/eslint?at=5c4c6e489221b9382dc5ae64)

> Is it possible to compose/group rules in a way that will allow me turn all the rules in the group on or off at the same time?
> 
> Let's say I wanted to take all the rules that warn in case of an error (e.g. all of the ones here: https://eslint.org/docs/rules/#possible-errors) and give them each their own pre-set options, and the same severity. Then give the new rule a name: `my-scope/errors`.
> 
> Then I'd like to enable that rule in a config to turn all those rules on:
> 
> ```
> "my-scope/errors": "error",
> ```
> 
> and be able to turn all of the rules off and on again in one fell swoop inline:
> 
> ```
> /* eslint-disable my-scope/errors */
> …
> /* eslint-enable my-scope/errors */
> ```
> 
> Bonus points if I could still manually configure some of the rules myself by configuring them later:
> 
> ```
> "my-scope/errors": "error",
> "no-debugger": "off",
> ```
> 
> To turn on all the rules except no-debugger,
> 
> ```
> /* eslint-disable my-scope/errors */
> /* eslint-enable no-empty */
> …
> /* eslint-enable my-scope/errors */
> ```
> 
> I'd like for the last line above to ideally return the config back to what would be in the config file, i.e. my-scope/errors on with the error severity, and no-debugger still off.

I created this rule by copying `joinReports` and tweaking it so that it accepts an object hash of rules (and optionally their options, as defaults), and passes through only the relevant part of the configure-time options to the individual rules' contexts (for those rules that are given configure-time options, those will override the creation-time options).

It also adjusts the joined rules' ids by prepending `groupRuleName:` to the rule name.

Please see the adjusted readme and tests for more information.